### PR TITLE
feat(errors): Throw an error screen when 5 error are thrown

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ var meisterPlayer = new Meister('#player', {
 });
 ```
 
+#### maxErrors *[Boolean]* (default: 5) ####
+
+Defines the maximum amount of errors that are allowed to be thrown.
+When the errors exceed this amount we throw a meister error.
+
+Example:
+
+``` JavaScript
+var meisterPlayer = new Meister('#player', {
+    Hls: {
+        maxErrors: 6,
+    }
+});
+```
+
 ### Item config
 
 These settings can be set per item. These will be available using the ```Hls: {}``` namespace.


### PR DESCRIPTION
This fixes an issue where HLS does not always recognise a fatal error. We give it a default threshold of 5 and subtract 1 if a playerTimeUpdate occurs so recover errors won't be seen as fatal.
