### PR TITLE
fix(quality): No longer switch to lowest quality on visibility change

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ var meisterPlayer = new Meister('#player', {
 });
 ```
 
-#### disableVisibilitySwitch *[Boolean]* (default: false) ####
+#### visibilitySwitch *[Boolean]* (default: false) ####
 
-Disables the quality switching when the player is not in an active tab or is minimized. (Default behavior is when the user either selects a different tab or minimizes the tab the player will select the lowest video quality to save bandwidth)
+Enables quality switching when the player is not in an active tab or is minimized. When the user either selects a different tab or minimizes the tab the player will select the lowest video quality to save bandwidth.
 
 Example:
 

--- a/src/js/Hls.js
+++ b/src/js/Hls.js
@@ -256,7 +256,7 @@ class Hls extends Meister.MediaPlugin {
 
             // Only start loading the stream when playback is requested.
             if (this.meister.config.autoplay) {
-                if (!this.config.disableVisibilitySwitch) {
+                if (this.config.visibilitySwitch) {
                     this.on('windowVisibilityChange', this.visibilityChange.bind(this));
                 }
                 resolve();
@@ -272,7 +272,7 @@ class Hls extends Meister.MediaPlugin {
                         this.hls.on(HlsJs.Events.MANIFEST_PARSED, startPlayback);
                     }
 
-                    if (!this.config.disableVisibilitySwitch) {
+                    if (this.config.visibilitySwitch) {
                         this.on('windowVisibilityChange', e => this.visibilityChange(e));
                     }
                 });


### PR DESCRIPTION
By 'manually' changing quality often it is possible to get stuck in a
fragment loading error state. This behaviour is now no longer the
default, but can still be enabled should it be required.