### PR TITLE
Always load stream info on load

### DIFF
--- a/src/js/Hls.js
+++ b/src/js/Hls.js
@@ -138,6 +138,7 @@ class Hls extends Meister.MediaPlugin {
 
             // Trigger this to make it look pretty.
             this.hls.on(HlsJs.Events.MANIFEST_LOADED, (event, data) => {
+                this.hls.startLoad(startPosition);
                 // data.levels contains audio stream here
                 if (this.audioMode) {
                     let onlyAudio = true;
@@ -161,27 +162,8 @@ class Hls extends Meister.MediaPlugin {
                             }
                         }
                     } else {
-                        if (this.meister.config.autoplay) {
-                            this.hls.startLoad(startPosition);
-                        } else {
-                            this.one('requestPlay', () => {
-                                if (this.manifestParsed) {
-                                    this.hls.startLoad(startPosition);
-                                } else {
-                                    const startPlayback = () => {
-                                        this.hls.startLoad(startPosition);
-                                        this.hls.off(HlsJs.Events.MANIFEST_PARSED, startPlayback);
-                                    };
-                                    this.hls.on(HlsJs.Events.MANIFEST_PARSED, startPlayback);
-                                }
-                            });
-                        }
                         resolve();
                     }
-                }
-
-                if (!this.audioMode && this.meister.config.autoplay) {
-                    this.hls.startLoad(startPosition);
                 }
 
                 if (!this.config.splashTitle) {

--- a/src/js/services/getAkamaiHls.js
+++ b/src/js/services/getAkamaiHls.js
@@ -1,4 +1,4 @@
-import loadScript from '@npm-wearetriple/load-script';
+import loadScript from '@meisterplayer/util-load-script';
 
 export default async function getAkamaiHls(hlsJsConfig, meisterConfig) {
     const scriptUrl = meisterConfig.akamaiScriptUrl || 'https://media-acceleration-host.akamaized.net/sdk/js/stable/hlsjs.min.js';


### PR DESCRIPTION
- fix(build): Update dependency name in import

- fix: Always fetch stream info on load
  Due to limitations in Hls.js we need to have called startLoad before
we're able to retrieve the duration of the stream. As we often need this
information before actually starting the stream we're now always calling
this method.